### PR TITLE
Add Laravel 10 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Just install the latest version using composer.
 composer require divineomega/laravel-extendable-basket
 ```
 
+## Compatibility
+
+This package supports Laravel versions 5.5 through 10 and requires PHP 8.1 or higher.
+
 ## Setup
 
 You need to perform various setup steps in order to make use of this package.

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
     "description": "🛒 Laravel Extendable Basket provides several abstract classes that implement basic ecommerce basket functionality",
     "type": "library",
     "require": {
-        "php": ">=7.1",
-        "laravel/framework": "^5.5||^6.0||^7.0||^8.0||^9.0"
+        "php": ">=8.1",
+        "laravel/framework": "^5.5||^6.0||^7.0||^8.0||^9.0||^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~5.0",
-        "phpunit/phpunit": "^8.0",
+        "orchestra/testbench": "^8.0",
+        "phpunit/phpunit": "^9.0",
         "php-coveralls/php-coveralls": "^2.1",
-        "doctrine/dbal": "^1.0||^2.0"
+        "doctrine/dbal": "^1.0||^2.0||^3.0"
     },
     "license": "LGPL-3.0-only",
     "authors": [


### PR DESCRIPTION
## Summary
- support Laravel 10 by updating composer.json requirements
- bump dev tools for PHP 8.1
- document compatibility in README

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*